### PR TITLE
Add TradeSight — self-hosted AI trading strategy lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ A curated list of awesome algorithmic trading tutorials, projects and communitie
 
 ## Projects
 
+- [TradeSight](https://github.com/rmbell09-lang/tradesight) - Self-hosted AI trading strategy lab. Runs overnight strategy tournaments, backtests technical indicators (RSI, Bollinger Bands), and executes paper trades via Alpaca — all from a local Python dashboard. MIT license.
+
 ## Articles
 
 - [10 Things to Know About Every Cash Flow Statement](https://investinganswers.com/education/financial-statement-analysis/10-things-know-about-every-cash-flow-statement-1023)


### PR DESCRIPTION
Adding TradeSight to the Projects section.

**TradeSight** is a self-hosted Python app for algorithmic trading research:
- Runs overnight AI strategy tournaments (RSI, Bollinger Bands, Confluence)
- Backtests against historical data with built-in risk guards (position limits, circuit breakers)
- Executes paper trades via Alpaca WebSocket API
- Local web dashboard — no cloud subscription, no data leaks
- MIT license, 169/169 tests passing

GitHub: https://github.com/rmbell09-lang/tradesight

Fits directly in the Projects section (currently empty). Happy to adjust the description format if needed.