### PR TITLE
Add DeepAlpha - AI crypto trading bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ A curated list of awesome algorithmic trading tutorials, projects and communitie
 
 ## Projects
 
+- [DeepAlpha](https://github.com/stefanoviana/deepalpha) - AI crypto trading bot with 3-model ML ensemble (XGBoost, HMM, Transformer), 70.9% walk-forward accuracy, supporting 12 exchanges. Open source, cloud platform with dashboard and backtesting.
+
 ## Articles
 
 - [10 Things to Know About Every Cash Flow Statement](https://investinganswers.com/education/financial-statement-analysis/10-things-know-about-every-cash-flow-statement-1023)


### PR DESCRIPTION
## Adding DeepAlpha

[DeepAlpha](https://github.com/stefanoviana/deepalpha) is an open-source AI crypto trading bot:

- **3-model ML ensemble** (XGBoost, HMM, Transformer) — 70.9% walk-forward accuracy
- **12 exchanges**: Bybit, Binance, OKX, Gate.io, KuCoin, Bitget, HTX, MEXC, BingX, Phemex, BitMart, WhiteBIT
- **Cloud platform** with dashboard, backtesting, TradingView webhooks
- **7-day free trial** — no credit card required
- **Open source** — PyPI: `pip install deepalpha-bot`
- **Non-custodial** — funds stay on user's exchange

Website: https://deepalphabot.com
GitHub: https://github.com/stefanoviana/deepalpha
PyPI: https://pypi.org/project/deepalpha-bot/